### PR TITLE
Fix a math display error on Chrome

### DIFF
--- a/layout/_partial/plugins/math.ejs
+++ b/layout/_partial/plugins/math.ejs
@@ -11,7 +11,12 @@
               skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
           }
       });
-
+      MathJax.Hub.Register.StartupHook("End Jax",function () {
+        var BROWSER = MathJax.Hub.Browser;
+        var jax = "HTML-CSS";
+        if (BROWSER.isMSIE && BROWSER.hasMathPlayer) jax = "NativeMML";
+        return MathJax.Hub.setRenderer(jax);
+      });
       MathJax.Hub.Queue(function() {
           var all = MathJax.Hub.getAllJax(), i;
           for(i=0; i < all.length; i += 1) {


### PR DESCRIPTION
it seems that when using the default `CommonHTML` as output will cause strange math display for `mathjax`. May be we can change default to  `HTML-CSS` and use `NativeMML` for IE with MathPlayer support. 
Before:
![image](https://user-images.githubusercontent.com/3437889/77755815-01a9be80-7069-11ea-8067-bf0a219f71fc.png)
After:
![image](https://user-images.githubusercontent.com/3437889/77755870-1dad6000-7069-11ea-8ee5-7271257348aa.png)
